### PR TITLE
Downgrade InnoSetup for compatibility with Vista

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
 clone_folder: C:\%MSYS_VERSION%\home\installer
 
 matrix:
-  fast_finish: true
+  fast_finish: false
 
 install:
     - ps: Import-Module .\scripts.ps1

--- a/dummy.conf
+++ b/dummy.conf
@@ -83,4 +83,5 @@ SigLevel = Never
 
 ## 3rd party msys2 packages (rtools hackers only!)
 [msys]
-Server = http://repo.msys2.org/msys/$arch/
+Server = https://repo.msys2.org/msys/$arch/
+SigLevel = Never

--- a/make-rtools-chroot.sh
+++ b/make-rtools-chroot.sh
@@ -7,7 +7,7 @@ pacman -Syy
 
 # rtools support pkgs (toolchains below)
 # Potential risk of PATH conflicts: curl, perl (via texinfo texinfo-tex), gpg
-_rtools_msys_pkgs="rsync winpty file bsdtar findutils libxml2 libexpat mintty msys2-launcher-git pacman curl make tar texinfo texinfo-tex patch diffutils gawk grep rebase zip unzip gzip"
+_rtools_msys_pkgs="rsync winpty file bsdtar findutils libxml2 libexpat mintty msys2-launcher pacman curl make tar texinfo texinfo-tex patch diffutils gawk grep rebase zip unzip gzip"
 
 _thisdir="$(dirname $0)"
 test "${_thisdir}" = "." && _thisdir=${PWD}

--- a/scripts.ps1
+++ b/scripts.ps1
@@ -10,10 +10,9 @@ $RTOOLS_MIRROR = "https://dl.bintray.com/rtools/installer/"
 # $RTOOLS_MIRROR = "https://ftp.opencpu.org/archive/rtools/4.0/"
 
 ### InnoSetup Mirror
-$INNO_MIRROR = "http://jrsoftware.org/download.php/is-unicode.exe?site=2"
-# $INNO_MIRROR = "https://github.com/jrsoftware/issrc/releases/download/is-5_6_1/innosetup-5.6.1-unicode.exe"
-# $INNO_MIRROR = "https://mlaan2.home.xs4all.nl/ispack/innosetup-5.6.1-unicode.exe"
-# $INNO_MIRROR = "http://files.jrsoftware.org/is/5/innosetup-5.6.1-unicode.exe"
+# $INNO_MIRROR = "http://www.jrsoftware.org/download.php/is.exe?site=2"
+### Latest InnoSetup does not support Vista anymore
+$INNO_MIRROR = "http://files.jrsoftware.org/is/6/innosetup-6.0.4.exe"
 
 function CheckExitCode($msg) {
   if ($LastExitCode -ne 0) {
@@ -55,15 +54,15 @@ function InstallRtools {
 }
 
 Function InstallInno {
-  $inno_url = "http://jrsoftware.org/download.php/is.exe?site=2"
+  Write-Host "Downloading InnoSetup from: " + $INNO_MIRROR
+  & "C:\Program Files\Git\mingw64\bin\curl.exe" -s -o ../innosetup.exe -L $INNO_MIRROR
+  CheckExitCode "Failed to download $INNO_MIRROR"
 
-  Progress ("Downloading InnoSetup from: " + $inno_url)
-  & "C:\Program Files\Git\mingw64\bin\curl.exe" -s -o ../innosetup.exe -L $inno_url
-
-  Progress "Installig InnoSetup"
+  Write-Host "Installig InnoSetup..."
   Start-Process -FilePath ..\innosetup.exe -ArgumentList "/ALLUSERS /SILENT" -NoNewWindow -Wait
+  CheckExitCode "Failed to install InnoSetup"
 
-  Progress "InnoSetup installation: Done"
+  Write-Host "InnoSetup installation: Done" -ForegroundColor Green
   Get-ItemProperty "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
 }
 


### PR DESCRIPTION
The latest innosetup no longer works on Vista (which is what CRAN still uses).

Note that upstream msys2 no longer builds binaries for 32-bit msys2 packages.